### PR TITLE
Filtered the model list to remove duplicate IDs

### DIFF
--- a/lib/hooks/use-models.tsx
+++ b/lib/hooks/use-models.tsx
@@ -31,7 +31,14 @@ export function useModels() {
 
   return {
     models:
-      data?.data.slice().sort((a, b) => a.name.localeCompare(b.name)) ?? [],
+      data?.data
+        .slice()
+        .sort(
+          (a, b) => a.id.localeCompare(b.id) || a.name.length - b.name.length
+        )
+        .filter(
+          (item, index, array) => index === 0 || item.id !== array[index - 1].id
+        ) ?? [],
     isLoading,
     error
   }


### PR DESCRIPTION
temporary fix; The names and other properties could be different, but the requests are routed purely on the basis of the model ID, which had duplicate IDs for variants.  A permanent fix is called for to have unique IDs for all variants.

Filtering also provides a better experience for the demo by removing redundancy in model selection.